### PR TITLE
Improve batching options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tix-factory/batch",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tix-factory/batch",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tix-factory/batch",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tix-factory/batch",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tix-factory/batch",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Merge multiple function calls into a single call.",
   "browser": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tix-factory/batch",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Merge multiple function calls into a single call.",
   "browser": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/batch/index.ts
+++ b/src/batch/index.ts
@@ -124,7 +124,7 @@ class Batch<TItem, TResult> extends EventTarget {
       }
 
       // Attempt to process the queue on the next event loop.
-      setTimeout(check, 0);
+      setTimeout(check, this.config.enqueueDeferDelay);
     });
   }
 

--- a/src/batch/index.ts
+++ b/src/batch/index.ts
@@ -8,11 +8,15 @@ import DeferredPromise from '../types/deferredPromise';
 // A class for batching and processing multiple single items into a single call.
 class Batch<TItem, TResult> extends EventTarget {
   private queueMap: { [key: string]: BatchItem<TItem, TResult> } = {};
-  private queueArray: BatchItem<TItem, TResult>[] = [];
   private promiseMap: { [key: string]: DeferredPromise<TResult>[] } = {};
   private limiter: PromiseQueue<void>;
   private concurrencyHandler: PromiseQueue<void>;
-  private config: BatchConfiguration;
+
+  // All the batch items waiting to be processed.
+  protected queueArray: BatchItem<TItem, TResult>[] = [];
+
+  // The configuration for this batch processor.
+  protected config: BatchConfiguration;
 
   constructor(configuration: BatchConfiguration) {
     super();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,5 @@ export { default as PromiseQueue } from './promise-queue';
 export { default as BatchItem } from './types/batchItem';
 export { default as BatchConfiguration } from './types/batchConfiguration';
 export { default as DeferredPromise } from './types/deferredPromise';
+export { default as PromiseQueueConfiguration } from './types/promiseQueueConfiguration';
 export { default as PromiseFactory } from './types/promiseFactory';

--- a/src/promise-queue/index.test.ts
+++ b/src/promise-queue/index.test.ts
@@ -110,7 +110,7 @@ describe('PromiseQueue', () => {
     // Adjust times because the event loop can run slightly faster than the exact specified time,
     // or sometimes slightly over.
     expect(time).toBeGreaterThanOrEqual(delayTime * 0.95);
-    expect(time).toBeLessThanOrEqual(delayTime * 1.1);
+    expect(time).toBeLessThanOrEqual(delayTime * 1.2);
   });
 
   it('Should wait between running queued promises', async () => {

--- a/src/promise-queue/index.ts
+++ b/src/promise-queue/index.ts
@@ -39,13 +39,13 @@ class PromiseQueue<TResult> {
   // Puts a function that will create the promise to run on the queue, and returns a promise
   // that will return the result of the enqueued promise.
   enqueue(createPromise: PromiseFactory<TResult>): Promise<TResult> {
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this.queue.push({
         deferredPromise: { resolve, reject },
         createPromise,
       });
 
-      await this.process();
+      setTimeout(this.process.bind(this), 0);
     });
   }
 

--- a/src/promise-queue/index.ts
+++ b/src/promise-queue/index.ts
@@ -1,15 +1,6 @@
 import PromiseFactory from '../types/promiseFactory';
+import PromiseQueueConfiguration from '../types/promiseQueueConfiguration';
 import QueuedPromise from '../types/queuedPromise';
-
-// Configuration for the PromiseQueue.
-type PromiseQueueConfiguration = {
-  // The number of promises that can be processed in parallel.
-  levelOfParallelism: number;
-
-  // The minimum delay between processing promises.
-  // Promises may run in parallel, as long as this amount have time has passed between them starting.
-  delayInMilliseconds?: number;
-};
 
 // A limiter for running promises in parallel.
 // Queue ensures order is maintained.

--- a/src/promise-queue/index.ts
+++ b/src/promise-queue/index.ts
@@ -30,13 +30,13 @@ class PromiseQueue<TResult> {
   // Puts a function that will create the promise to run on the queue, and returns a promise
   // that will return the result of the enqueued promise.
   enqueue(createPromise: PromiseFactory<TResult>): Promise<TResult> {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       this.queue.push({
         deferredPromise: { resolve, reject },
         createPromise,
       });
 
-      setTimeout(this.process.bind(this), 0);
+      await this.process();
     });
   }
 

--- a/src/types/batchConfiguration.ts
+++ b/src/types/batchConfiguration.ts
@@ -15,6 +15,10 @@ type BatchConfiguration = {
   // The maximum number of batches that can be processed in parallel.
   // If unspecified, the level of parallelism is infinity.
   levelOfParallelism?: number;
+
+  // The time, in milliseconds, to defer processing a batch after an item has been enqueued.
+  // If unspecified, will default to zero.
+  enqueueDeferDelay?: number;
 };
 
 export default BatchConfiguration;

--- a/src/types/promiseQueueConfiguration.ts
+++ b/src/types/promiseQueueConfiguration.ts
@@ -1,0 +1,11 @@
+// Configuration for the PromiseQueue.
+type PromiseQueueConfiguration = {
+  // The number of promises that can be processed in parallel.
+  levelOfParallelism: number;
+
+  // The minimum delay between processing promises.
+  // Promises may run in parallel, as long as this amount have time has passed between them starting.
+  delayInMilliseconds?: number;
+};
+
+export default PromiseQueueConfiguration;


### PR DESCRIPTION
This review makes the batch processor class slightly more flexible.
- `getBatch` can now be properly overridden, by making the `config` and `queueArray` `protected`
- Added `enqueueDeferDelay` to allow for time for batch sizes to build when items are added sequentially
- Exposed `PromiseQueueConfiguration` type